### PR TITLE
Changed setup.py details for new name and URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='django-digitaldiocese-cofecms',
+    name='pycofecms',
     packages=find_packages(),
     version='0.0.1',
     author='Blanc Ltd',
     author_email='studio@blanc.ltd.uk',
     description='Python client for the Church of England CMS API',
     license='BSD',
-    url='https://github.com/blancltd/django-digitaldiocese-cofecms',
+    url='https://github.com/blancltd/pycofecms/',
     include_package_data=True,
     install_requires=[
         'requests>=2.0.0',


### PR DESCRIPTION
Fixes #7

Have tested install using `pip install -e ~/Projects/pycofecms/`.