### PR TITLE
Update rate limit headers, and be more defensive

### DIFF
--- a/cofecms/api.py
+++ b/cofecms/api.py
@@ -469,8 +469,12 @@ class CofeCMS(object):
         result.diocese_id = diocese_id
         result.search_params = search_params
         result.basic_params = basic_params
-        result.rate_limit = int(response.headers['X-Rate-Limit'])
-        result.rate_limit_remaining = int(response.headers['X-Rate-Limit-Remaining'])
+        try:
+            result.rate_limit = int(response.headers.get('X-RateLimit-Limit'))
+            result.rate_limit_remaining = int(response.headers.get('X-RateLimit-Remaining'))
+        except:  # noqa:E722
+            result.rate_limit = None
+            result.rate_limit_remaining = None
         return result
 
     def paged_get(self, endpoint_url, diocese_id=None, search_params=None, **basic_params):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -337,8 +337,8 @@ class CofeCMSTest(TestCase):
 
         headers = {
             'X-Total-Count': '678',
-            'X-Rate-Limit': '60',
-            'X-Rate-Limit-Remaining': '59',
+            'X-RateLimit-Limit': '60',
+            'X-RateLimit-Remaining': '59',
         }
         mock_response = mock.Mock(spec=requests.Response)
         mock_response.headers = headers
@@ -385,7 +385,9 @@ class CofeCMSTest(TestCase):
             return_value=request_params,
         )
 
-        headers = {'X-Total-Count': '678', 'X-Rate-Limit': '60', 'X-Rate-Limit-Remaining': '59'}
+        headers = {
+            'X-Total-Count': '678', 'X-RateLimit-Limit': '60', 'X-RateLimit-Remaining': '59'
+        }
         mock_response = mock.Mock(spec=requests.Response)
         mock_response.headers = headers
         mock_response.json.return_value = {'a_list': ['some_value']}
@@ -420,8 +422,8 @@ class CofeCMSTest(TestCase):
         get_return = CofeCMSResult([{'contact': ['id', 'surname']}])
         get_return.headers = {
             'X-Total-Count': '678',
-            'X-Rate-Limit': '60',
-            'X-Rate-Limit-Remaining': '59',
+            'X-RateLimit-Limit': '60',
+            'X-RateLimit-Remaining': '59',
         }
         get_return.basic_params = {'limit': 100, 'offset': 0}
         self.cofecms.get = mock.Mock(spec=self.cofecms.get, return_value=get_return)
@@ -446,8 +448,8 @@ class CofeCMSTest(TestCase):
         get_return = CofeCMSResult([{'contact': ['id', 'surname']}])
         get_return.headers = {
             'X-Total-Count': '678',
-            'X-Rate-Limit': '60',
-            'X-Rate-Limit-Remaining': '59',
+            'X-RateLimit-Limit': '60',
+            'X-RateLimit-Remaining': '59',
         }
         get_return.basic_params = {}
         self.cofecms.get = mock.Mock(spec=self.cofecms.get, return_value=get_return)


### PR DESCRIPTION
Related docs: https://cmsapi.cofeportal.org/rate-limiting

I think they changed the headers slightly, so some of our sites are erroring out.